### PR TITLE
update ffmpeg-for-homebridge to 0.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "build": "rimraf ./dist && tsc"
   },
   "dependencies": {
-    "ffmpeg-for-homebridge": "0.0.4",
+    "ffmpeg-for-homebridge": "0.0.5",
     "ip": "^1.1.5",
     "request": "^2.88.2",
     "request-promise-native": "^1.0.8",


### PR DESCRIPTION
This was just compiled this morning. I don't think it has been released to npm yet. Once it has you could merge or close and change yourself.